### PR TITLE
fix(package.json): remove erroneous comma from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "io.extendreality.zinnia.unity": "1.9.0",
-        "io.extendreality.tilia.utilities.shaders.unity": "1.1.0",
+        "io.extendreality.tilia.utilities.shaders.unity": "1.1.0"
     },
     "files": [
         "*.md",


### PR DESCRIPTION
There was an extra comma at the end of the dependencies causing
the package.json to be invalid. It has now been removed.