### PR TITLE
fix(package.json): provide correct version to shader dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     },
     "dependencies": {
         "io.extendreality.zinnia.unity": "1.9.0",
-        "io.extendreality.tilia.utilities.shaders.unity": "1.1.0"
+        "io.extendreality.tilia.utilities.shaders.unity": "1.0.1"
     },
     "files": [
         "*.md",


### PR DESCRIPTION
The wrong shader package version was used due to an issue with the
README on the shader repo displaying the wrong version. This has
now been fixed by providing the correct version for the shader
package dependency.