### PR TITLE
fix(Scripts): update namespace to correct tilia namespace

### DIFF
--- a/Runtime/SharedResources/Scripts/TeleporterConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/TeleporterConfigurator.cs
@@ -1,4 +1,4 @@
-﻿namespace VRTK.Prefabs.Locomotion.Teleporters
+﻿namespace Tilia.Locomotors.Teleporter
 {
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;

--- a/Runtime/SharedResources/Scripts/TeleporterFacade.cs
+++ b/Runtime/SharedResources/Scripts/TeleporterFacade.cs
@@ -1,4 +1,4 @@
-﻿namespace VRTK.Prefabs.Locomotion.Teleporters
+﻿namespace Tilia.Locomotors.Teleporter
 {
     using Malimbe.MemberChangeMethod;
     using Malimbe.MemberClearanceMethod;


### PR DESCRIPTION
The code still had the VRTK.Prefabs namespace as it was copied over
from the VRTK.Prefabs repo, this has now been updated to be in
line with the Tilia repo name instead.