### PR TITLE
fix(Prefabs): allow teleport to same location as previous location

### DIFF
--- a/Runtime/Prefabs/Locomotors.Teleporter.Dash.prefab
+++ b/Runtime/Prefabs/Locomotors.Teleporter.Dash.prefab
@@ -71,7 +71,7 @@ GameObject:
   - component: {fileID: 7466508404443556258}
   - component: {fileID: 5950170169637845304}
   m_Layer: 0
-  m_Name: Teleporter.Dash
+  m_Name: Locomotors.Teleporter.Dash
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -171,6 +171,8 @@ MonoBehaviour:
   searchDirection: {x: 0, y: -1, z: 0}
   originOffset: -0.01
   maximumDistance: 50
+  mustChangePosition: 0
+  positionChangedEqualityThreshold: 0.0001
   destinationOffset: {x: 0, y: 0, z: 0}
   targetValidity:
     field: {fileID: 0}
@@ -231,6 +233,7 @@ MonoBehaviour:
     zState: 0
   applyTransformations: 3
   transitionDuration: 0.25
+  shouldApplyToEqualProperties: 1
   transitionDestinationThreshold: 0.01
   isTransitionDestinationDynamic: 0
   BeforeTransformUpdated:

--- a/Runtime/Prefabs/Locomotors.Teleporter.Instant.prefab
+++ b/Runtime/Prefabs/Locomotors.Teleporter.Instant.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 8762128706450136148}
   - component: {fileID: 6759483569300406686}
   m_Layer: 0
-  m_Name: Teleporter.Instant
+  m_Name: Locomotors.Teleporter.Instant
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -171,6 +171,8 @@ MonoBehaviour:
   searchDirection: {x: 0, y: -1, z: 0}
   originOffset: -0.01
   maximumDistance: 50
+  mustChangePosition: 0
+  positionChangedEqualityThreshold: 0.0001
   destinationOffset: {x: 0, y: 0, z: 0}
   targetValidity:
     field: {fileID: 0}
@@ -242,6 +244,7 @@ MonoBehaviour:
     zState: 0
   applyTransformations: 3
   transitionDuration: 0
+  shouldApplyToEqualProperties: 1
   transitionDestinationThreshold: 0.01
   isTransitionDestinationDynamic: 0
   BeforeTransformUpdated:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "url": "https://github.com/ExtendRealityLtd"
     },
     "dependencies": {
-        "io.extendreality.zinnia.unity": "1.15.0",
+        "io.extendreality.zinnia.unity": "1.16.0",
         "io.extendreality.tilia.utilities.shaders.unity": "1.0.2"
     },
     "files": [


### PR DESCRIPTION
Zinnia 1.16.0 has some changes to the SurfaceLocator and the
TransformPropertyApplier that allows both components to still operate
if the previous location is the same as the current loaction.

This limitation in Zinnia 1.15.0 meant that you could not teleport to
the same position that you were currently on, which was fine in most
cases but there are some occasions where you do want to teleport
back to where you're currently standing. This is now the default
setting, but its still possible to switch the settings to have it
work the way it did before.