### PR TITLE
feat(prefab): add ability to customise snap to floor thresholds

### DIFF
--- a/Runtime/Prefabs/Locomotors.Teleporter.Dash.prefab
+++ b/Runtime/Prefabs/Locomotors.Teleporter.Dash.prefab
@@ -29,7 +29,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8221229427137139004}
-  - {fileID: 6787288796672179177}
+  - {fileID: 6501794960178266415}
   m_Father: {fileID: 7466508404443556258}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -49,17 +49,19 @@ MonoBehaviour:
   surfaceTeleporter: {fileID: 4061554705455466048}
   modifyTeleporter: {fileID: 0}
   surfaceLocatorAliases:
-  - {fileID: 7268431025196971884}
+  - {fileID: 1549196070032961349}
   surfaceLocatorRules:
-  - {fileID: 7268431025196971884}
+  - {fileID: 1549196070032961349}
   - {fileID: 4061554705455466048}
   transformPropertyApplierAliases:
-  - {fileID: 3589334001372862834}
+  - {fileID: 5462094480993792734}
   - {fileID: 1830882504103230646}
   transformPropertyApplierIgnoreOffsetAliases:
   - {fileID: 1830882504103230646}
   cameraColorOverlays:
   - {fileID: 7662364483342452087}
+  snapToFloorThresholdController: {fileID: 7623627598764308129}
+  snapToFloorBlinkThresholdController: {fileID: 4552261764274497987}
 --- !u!1 &2262987785075144963
 GameObject:
   m_ObjectHideFlags: 0
@@ -112,6 +114,8 @@ MonoBehaviour:
     field: {fileID: 0}
   targetValidity:
     field: {fileID: 0}
+  snapToFloorThreshold: 1e-45
+  snapToFloorBlinkThreshold: 0.3
   Teleporting:
     m_PersistentCalls:
       m_Calls: []
@@ -261,6 +265,17 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 4901402792992508487}
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
       - m_Target: {fileID: 1683957728789067024}
         m_MethodName: NotifyTeleporting
         m_Mode: 0
@@ -312,12 +327,43 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: Zinnia.Tracking.Modification.TransformPropertyApplier+UnityEvent,
       Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+--- !u!1 &7724628601485169068
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6501794960178266415}
+  m_Layer: 0
+  m_Name: SnapToFloorLogic
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6501794960178266415
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7724628601485169068}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 6787288796672179177}
+  m_Father: {fileID: 1817818269086549033}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &6558078218179066450
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 1817818269086549033}
+    m_TransformParent: {fileID: 6501794960178266415}
     m_Modifications:
     - target: {fileID: 1163974902123328183, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
         type: 3}
@@ -362,7 +408,7 @@ PrefabInstance:
     - target: {fileID: 374839283324289467, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 374839283324289467, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
         type: 3}
@@ -393,48 +439,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 6558078218179066450}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &7732585858515215388 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3480526847488826958, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
-    type: 3}
-  m_PrefabInstance: {fileID: 6558078218179066450}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &7268431025196971884 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4601657258391178558, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
-    type: 3}
-  m_PrefabInstance: {fileID: 6558078218179066450}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7732585858515215388}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f7fe420339e958499aa62748577d273, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &3589334001372862834 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7695834987094188832, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
-    type: 3}
-  m_PrefabInstance: {fileID: 6558078218179066450}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7732585858515215388}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2dec536a0cacdc84b84a384ca98d6493, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &7662364483342452087 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3554701860725620517, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
-    type: 3}
-  m_PrefabInstance: {fileID: 6558078218179066450}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b0b7e5e5f39690a43a2fd345ee851b08, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &5083811904906470819 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2130108729906962417, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
@@ -445,6 +449,78 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 406d478cdbf496a4ead48dfdc7df8d0c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &7732585858515215388 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3480526847488826958, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
+    type: 3}
+  m_PrefabInstance: {fileID: 6558078218179066450}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1549196070032961349 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5655712967484036375, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
+    type: 3}
+  m_PrefabInstance: {fileID: 6558078218179066450}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f7fe420339e958499aa62748577d273, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &7623627598764308129 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3660979598859947251, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
+    type: 3}
+  m_PrefabInstance: {fileID: 6558078218179066450}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d1d120f24812793439e55c40dd45fccb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5462094480993792734 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1211389792567920780, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
+    type: 3}
+  m_PrefabInstance: {fileID: 6558078218179066450}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2dec536a0cacdc84b84a384ca98d6493, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4552261764274497987 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7218734259541283729, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
+    type: 3}
+  m_PrefabInstance: {fileID: 6558078218179066450}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d1d120f24812793439e55c40dd45fccb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &4901402792992508487 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2235965453378203669, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
+    type: 3}
+  m_PrefabInstance: {fileID: 6558078218179066450}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7662364483342452087 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3554701860725620517, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
+    type: 3}
+  m_PrefabInstance: {fileID: 6558078218179066450}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4901402792992508487}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b0b7e5e5f39690a43a2fd345ee851b08, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1971332698191617542 stripped

--- a/Runtime/Prefabs/Locomotors.Teleporter.Instant.prefab
+++ b/Runtime/Prefabs/Locomotors.Teleporter.Instant.prefab
@@ -52,6 +52,8 @@ MonoBehaviour:
     field: {fileID: 0}
   targetValidity:
     field: {fileID: 0}
+  snapToFloorThreshold: 1e-45
+  snapToFloorBlinkThreshold: 0.3
   Teleporting:
     m_PersistentCalls:
       m_Calls: []
@@ -92,7 +94,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1472956425516877046}
-  - {fileID: 7823358654029524927}
+  - {fileID: 7118190462417118764}
   m_Father: {fileID: 8762128706450136148}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -112,17 +114,19 @@ MonoBehaviour:
   surfaceTeleporter: {fileID: 536479425143457731}
   modifyTeleporter: {fileID: 0}
   surfaceLocatorAliases:
-  - {fileID: 6232361262328668986}
+  - {fileID: 2872370309144820499}
   surfaceLocatorRules:
-  - {fileID: 6232361262328668986}
+  - {fileID: 2872370309144820499}
   - {fileID: 536479425143457731}
   transformPropertyApplierAliases:
-  - {fileID: 246726338017611044}
+  - {fileID: 8749981636840121992}
   - {fileID: 103839708580330939}
   transformPropertyApplierIgnoreOffsetAliases:
   - {fileID: 103839708580330939}
   cameraColorOverlays:
   - {fileID: 6410104322628522273}
+  snapToFloorThresholdController: {fileID: 6588762840587281143}
+  snapToFloorBlinkThresholdController: {fileID: 977155746534194581}
 --- !u!1 &6210428687401589529
 GameObject:
   m_ObjectHideFlags: 0
@@ -323,12 +327,43 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: Zinnia.Tracking.Modification.TransformPropertyApplier+UnityEvent,
       Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+--- !u!1 &8989156614657649529
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7118190462417118764}
+  m_Layer: 0
+  m_Name: SnapToFloorLogic
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7118190462417118764
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8989156614657649529}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7823358654029524927}
+  m_Father: {fileID: 5936397195636509551}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &7611529125206978052
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 5936397195636509551}
+    m_TransformParent: {fileID: 7118190462417118764}
     m_Modifications:
     - target: {fileID: 1163974902123328183, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
         type: 3}
@@ -373,7 +408,7 @@ PrefabInstance:
     - target: {fileID: 374839283324289467, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 374839283324289467, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
         type: 3}
@@ -404,34 +439,70 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 7611529125206978052}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &8371699073636397557 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2130108729906962417, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
+    type: 3}
+  m_PrefabInstance: {fileID: 7611529125206978052}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 406d478cdbf496a4ead48dfdc7df8d0c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &6479771475221442634 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3480526847488826958, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
     type: 3}
   m_PrefabInstance: {fileID: 7611529125206978052}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &6232361262328668986 stripped
+--- !u!114 &2872370309144820499 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4601657258391178558, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
+  m_CorrespondingSourceObject: {fileID: 5655712967484036375, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
     type: 3}
   m_PrefabInstance: {fileID: 7611529125206978052}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6479771475221442634}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f7fe420339e958499aa62748577d273, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &246726338017611044 stripped
+--- !u!114 &6588762840587281143 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7695834987094188832, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
+  m_CorrespondingSourceObject: {fileID: 3660979598859947251, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
     type: 3}
   m_PrefabInstance: {fileID: 7611529125206978052}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6479771475221442634}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d1d120f24812793439e55c40dd45fccb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8749981636840121992 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1211389792567920780, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
+    type: 3}
+  m_PrefabInstance: {fileID: 7611529125206978052}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 2dec536a0cacdc84b84a384ca98d6493, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &977155746534194581 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7218734259541283729, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
+    type: 3}
+  m_PrefabInstance: {fileID: 7611529125206978052}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d1d120f24812793439e55c40dd45fccb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &6410104322628522273 stripped
@@ -444,18 +515,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b0b7e5e5f39690a43a2fd345ee851b08, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &8371699073636397557 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 2130108729906962417, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
-    type: 3}
-  m_PrefabInstance: {fileID: 7611529125206978052}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 406d478cdbf496a4ead48dfdc7df8d0c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &3024440555512302160 stripped

--- a/Runtime/SharedResources/NestedPrefabs/SnapToFloor.prefab
+++ b/Runtime/SharedResources/NestedPrefabs/SnapToFloor.prefab
@@ -27,11 +27,11 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 4571630719193713254}
-  - {fileID: 3199935394603094063}
-  - {fileID: 8331258515199282043}
   - {fileID: 5590959520585286125}
+  - {fileID: 4571630719193713254}
+  - {fileID: 2610266345189395638}
   - {fileID: 235444694536354417}
+  - {fileID: 8331258515199282043}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -120,8 +120,118 @@ MonoBehaviour:
       Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements:
-  - {fileID: 8074351097571158537}
+  - {fileID: 3753995684529238138}
   - {fileID: 5560459130415996843}
+--- !u!1 &2025998012479814019
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7195539714814839669}
+  - component: {fileID: 5655712967484036375}
+  - component: {fileID: 3753995684529238138}
+  m_Layer: 0
+  m_Name: LocateFloor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7195539714814839669
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025998012479814019}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4571630719193713254}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5655712967484036375
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025998012479814019}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f7fe420339e958499aa62748577d273, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  searchOrigin: {fileID: 0}
+  searchDirection: {x: 0, y: -1, z: 0}
+  originOffset: -0.05
+  maximumDistance: 50
+  mustChangePosition: 1
+  positionChangedEqualityThreshold: 0.0001
+  destinationOffset: {x: 0, y: 0, z: 0}
+  targetValidity:
+    field: {fileID: 0}
+  locatorTermination:
+    field: {fileID: 0}
+  physicsCast: {fileID: 2130108729906962417}
+  SurfaceLocated:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1211389792567920780}
+        m_MethodName: set_Source
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 3660979598859947251}
+        m_MethodName: Receive
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 7218734259541283729}
+        m_MethodName: Receive
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: Zinnia.Tracking.SurfaceLocator+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &3753995684529238138
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025998012479814019}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 5655712967484036375}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0
 --- !u!1 &2235965453378203669
 GameObject:
   m_ObjectHideFlags: 0
@@ -133,7 +243,7 @@ GameObject:
   - component: {fileID: 3199935394603094063}
   - component: {fileID: 3554701860725620517}
   m_Layer: 0
-  m_Name: CameraFader
+  m_Name: CameraColorOverlay
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -150,8 +260,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 374839283324289467}
-  m_RootOrder: 1
+  m_Father: {fileID: 2610266345189395638}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &3554701860725620517
 MonoBehaviour:
@@ -197,6 +307,114 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: Zinnia.Visual.CameraColorOverlay+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
+--- !u!1 &2876509775659257825
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8757416647604212321}
+  - component: {fileID: 3660979598859947251}
+  m_Layer: 0
+  m_Name: CheckSnapThreshold
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8757416647604212321
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2876509775659257825}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4571630719193713254}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3660979598859947251
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2876509775659257825}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d1d120f24812793439e55c40dd45fccb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ActivationStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Action.Action+BooleanUnityEvent, Zinnia.Runtime, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  defaultValue: 0
+  sources: []
+  Activated:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1211389792567920780}
+        m_MethodName: Apply
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 4294519157332793404}
+        m_MethodName: SetActive
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+    m_TypeName: Zinnia.Action.BooleanAction+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  ValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Action.BooleanAction+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  ValueUnchanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Action.BooleanAction+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  Deactivated:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4294519157332793404}
+        m_MethodName: SetActive
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: Zinnia.Action.BooleanAction+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  changeDistance: 0.01
+  checkAxis:
+    xState: 0
+    yState: 1
+    zState: 0
 --- !u!1 &3480526847488826958
 GameObject:
   m_ObjectHideFlags: 0
@@ -206,10 +424,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4571630719193713254}
-  - component: {fileID: 4601657258391178558}
-  - component: {fileID: 7695834987094188832}
-  - component: {fileID: 2464578729595891918}
-  - component: {fileID: 8074351097571158537}
   m_Layer: 0
   m_Name: SurfaceLocator
   m_TagString: Untagged
@@ -227,116 +441,52 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 7195539714814839669}
+  - {fileID: 8757416647604212321}
+  - {fileID: 92987762500409198}
+  - {fileID: 3077503582736538865}
   m_Father: {fileID: 374839283324289467}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4294519157332793404
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1491759551649049179}
+  - component: {fileID: 7218734259541283729}
+  m_Layer: 0
+  m_Name: ShouldBlinkOnSnap
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1491759551649049179
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4294519157332793404}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3077503582736538865}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &4601657258391178558
+--- !u!114 &7218734259541283729
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3480526847488826958}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3f7fe420339e958499aa62748577d273, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  searchOrigin: {fileID: 0}
-  searchDirection: {x: 0, y: -1, z: 0}
-  originOffset: -0.05
-  maximumDistance: 50
-  destinationOffset: {x: 0, y: 0, z: 0}
-  targetValidity:
-    field: {fileID: 0}
-  locatorTermination:
-    field: {fileID: 0}
-  physicsCast: {fileID: 2130108729906962417}
-  SurfaceLocated:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 7695834987094188832}
-        m_MethodName: set_Source
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 7695834987094188832}
-        m_MethodName: Apply
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 2464578729595891918}
-        m_MethodName: Receive
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-    m_TypeName: Zinnia.Tracking.SurfaceLocator+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
---- !u!114 &7695834987094188832
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3480526847488826958}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2dec536a0cacdc84b84a384ca98d6493, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  source:
-    transform: {fileID: 0}
-    useLocalValues: 0
-  target: {fileID: 0}
-  offset: {fileID: 0}
-  applyPositionOffsetOnAxis:
-    xState: 1
-    yState: 0
-    zState: 1
-  applyRotationOffsetOnAxis:
-    xState: 0
-    yState: 0
-    zState: 0
-  applyTransformations: 1
-  transitionDuration: 0
-  transitionDestinationThreshold: 0.01
-  isTransitionDestinationDynamic: 0
-  BeforeTransformUpdated:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: Zinnia.Tracking.Modification.TransformPropertyApplier+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  AfterTransformUpdated:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: Zinnia.Tracking.Modification.TransformPropertyApplier+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
---- !u!114 &2464578729595891918
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3480526847488826958}
+  m_GameObject: {fileID: 4294519157332793404}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d1d120f24812793439e55c40dd45fccb, type: 3}
@@ -363,9 +513,25 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 2235965453378203669}
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
     m_TypeName: Zinnia.Action.BooleanAction+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
   ValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Action.BooleanAction+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  ValueUnchanged:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: Zinnia.Action.BooleanAction+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
@@ -375,27 +541,42 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: Zinnia.Action.BooleanAction+UnityEvent, Zinnia.Runtime, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
-  changeDistance: 0.5
+  changeDistance: 0.3
   checkAxis:
     xState: 0
     yState: 1
     zState: 0
---- !u!114 &8074351097571158537
-MonoBehaviour:
+--- !u!1 &4458661293946643456
+GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3480526847488826958}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  source:
-    field: {fileID: 4601657258391178558}
-  onlyProcessOnActiveAndEnabled: 1
-  interval: 0
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3077503582736538865}
+  m_Layer: 0
+  m_Name: BlinkLogic
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3077503582736538865
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4458661293946643456}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1491759551649049179}
+  m_Father: {fileID: 4571630719193713254}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4636857964133147732
 GameObject:
   m_ObjectHideFlags: 0
@@ -426,7 +607,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 374839283324289467}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &5560459130415996843
 MonoBehaviour:
@@ -512,7 +693,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 374839283324289467}
-  m_RootOrder: 3
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2130108729906962417
 MonoBehaviour:
@@ -530,6 +711,37 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 4
   triggerInteraction: 1
+--- !u!1 &5122120090706552259
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2610266345189395638}
+  m_Layer: 0
+  m_Name: CameraFader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2610266345189395638
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5122120090706552259}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3199935394603094063}
+  m_Father: {fileID: 374839283324289467}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6187257659837233587
 GameObject:
   m_ObjectHideFlags: 0
@@ -560,7 +772,7 @@ Transform:
   m_Children:
   - {fileID: 2328993843930049245}
   m_Father: {fileID: 374839283324289467}
-  m_RootOrder: 2
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &3743196964653568546
 MonoBehaviour:
@@ -576,3 +788,74 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   processMoment: 2
   processes: {fileID: 1524631959400516128}
+--- !u!1 &6488069467770837108
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 92987762500409198}
+  - component: {fileID: 1211389792567920780}
+  m_Layer: 0
+  m_Name: MoveTargetToFoundFloor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &92987762500409198
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6488069467770837108}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4571630719193713254}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1211389792567920780
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6488069467770837108}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2dec536a0cacdc84b84a384ca98d6493, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    transform: {fileID: 0}
+    useLocalValues: 0
+  target: {fileID: 0}
+  offset: {fileID: 0}
+  applyPositionOffsetOnAxis:
+    xState: 1
+    yState: 0
+    zState: 1
+  applyRotationOffsetOnAxis:
+    xState: 0
+    yState: 0
+    zState: 0
+  applyTransformations: 1
+  transitionDuration: 0
+  shouldApplyToEqualProperties: 0
+  transitionDestinationThreshold: 0.01
+  isTransitionDestinationDynamic: 0
+  BeforeTransformUpdated:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Tracking.Modification.TransformPropertyApplier+UnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  AfterTransformUpdated:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Tracking.Modification.TransformPropertyApplier+UnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null

--- a/Runtime/SharedResources/Scripts/TeleporterConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/TeleporterConfigurator.cs
@@ -4,6 +4,7 @@
     using Malimbe.XmlDocumentationAttribute;
     using System.Collections.Generic;
     using UnityEngine;
+    using Zinnia.Action;
     using Zinnia.Data.Attribute;
     using Zinnia.Data.Enum;
     using Zinnia.Data.Type;
@@ -71,6 +72,18 @@
         [Serialized]
         [field: DocumentedByXml, Restricted]
         public List<CameraColorOverlay> CameraColorOverlays { get; protected set; } = new List<CameraColorOverlay>();
+        /// <summary>
+        /// The <see cref="SurfaceChangeAction"/> that holds the threshold of whether a snap to floor should even occur.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml, Restricted]
+        public SurfaceChangeAction SnapToFloorThresholdController { get; protected set; }
+        /// <summary>
+        /// The <see cref="SurfaceChangeAction"/> that holds the threshold of whether a blink should occur when snapping to floor.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml, Restricted]
+        public SurfaceChangeAction SnapToFloorBlinkThresholdController { get; protected set; }
         #endregion
 
         /// <summary>
@@ -178,6 +191,17 @@
             }
         }
 
+        /// <summary>
+        /// Configures the surface change actions that determine the snap to floor functionality.
+        /// </summary>
+        /// <param name="snapToFloorThreshold">The threshold of whether the change distance should do a new snap to the found floor.</param>
+        /// <param name="snapToFloorBlinkThreshold">The threshold of whether to blink the view.</param>
+        public virtual void ConfigureSurfaceChangeActions(float snapToFloorThreshold, float snapToFloorBlinkThreshold)
+        {
+            SnapToFloorThresholdController.ChangeDistance = snapToFloorThreshold;
+            SnapToFloorBlinkThresholdController.ChangeDistance = snapToFloorBlinkThreshold;
+        }
+
         protected virtual void OnEnable()
         {
             ConfigureSurfaceLocatorAliases();
@@ -185,6 +209,7 @@
             ConfigureTransformPropertyAppliers();
             ConfigureCameraColorOverlays();
             ConfigureRotationAbility(Facade.ApplyDestinationRotation);
+            ConfigureSurfaceChangeActions(Facade.SnapToFloorThreshold, Facade.SnapToFloorBlinkThreshold);
         }
 
         /// <summary>

--- a/Runtime/SharedResources/Scripts/TeleporterFacade.cs
+++ b/Runtime/SharedResources/Scripts/TeleporterFacade.cs
@@ -73,6 +73,21 @@
         public RuleContainer TargetValidity { get; set; }
         #endregion
 
+        #region Floor Snap Settings
+        /// <summary>
+        /// The distance between the previous floor and current floor to determine if a snap to the new floor is required.
+        /// </summary>
+        [Serialized]
+        [field: Header("Floor Snap Settings"), DocumentedByXml]
+        public float SnapToFloorThreshold { get; set; } = float.Epsilon;
+        /// <summary>
+        /// The distance between the previous floor and current floor to determine if the screen should blink when snapping to the new floor.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public float SnapToFloorBlinkThreshold { get; set; } = 0.3f;
+        #endregion
+
         #region Teleporter Events
         /// <summary>
         /// Emitted when the teleporting is about to initiate.
@@ -184,6 +199,24 @@
         protected virtual void OnAfterTargetValidityChange()
         {
             Configuration.ConfigureSurfaceLocatorRules();
+        }
+
+        /// <summary>
+        /// Called after <see cref="SnapToFloorThreshold"/> has been changed.
+        /// </summary>
+        [CalledAfterChangeOf(nameof(SnapToFloorThreshold))]
+        protected virtual void OnAfterSnapToFloorThresholdChange()
+        {
+            Configuration.ConfigureSurfaceChangeActions(SnapToFloorThreshold, SnapToFloorBlinkThreshold);
+        }
+
+        /// <summary>
+        /// Called after <see cref="SnapToFloorBlinkThreshold"/> has been changed.
+        /// </summary>
+        [CalledAfterChangeOf(nameof(SnapToFloorBlinkThreshold))]
+        protected virtual void OnAfterSnapToFloorBlinkThresholdChange()
+        {
+            Configuration.ConfigureSurfaceChangeActions(SnapToFloorThreshold, SnapToFloorBlinkThreshold);
         }
     }
 }


### PR DESCRIPTION
The snap to floor threshold has now been exposed in the facade and
the snap to floor mechanism has been updated so two Surface Change
Actions are now used. The first one determines if a snap to the
nearest floor can even take place (if the distance between the old
and new floor exceeds the threshold). The second one determines
if the snap teleport will blink the view.

This enables now certain small changes in floor height not to
teleport the target at all and to only blink the view when the floor
height has changed substantially enough.