### PR TITLE
feat(Facade): add destination offset property

### DIFF
--- a/Documentation/API/TeleporterConfigurator.md
+++ b/Documentation/API/TeleporterConfigurator.md
@@ -7,6 +7,10 @@ Sets up the Teleport Prefab based on the provided user settings.
 * [Inheritance]
 * [Namespace]
 * [Syntax]
+* [Fields]
+  * [cachedLocators]
+  * [cachedSnapToFloorBlinkThreshold]
+  * [resetCachedDataRoutine]
 * [Properties]
   * [CameraColorOverlays]
   * [Facade]
@@ -23,6 +27,7 @@ Sets up the Teleport Prefab based on the provided user settings.
   * [ConfigureRotationAbility(Boolean)]
   * [ConfigureSurfaceChangeActions(Single, Single)]
   * [ConfigureSurfaceLocatorAliases()]
+  * [ConfigureSurfaceLocatorOffsets()]
   * [ConfigureSurfaceLocatorRules()]
   * [ConfigureTransformPropertyAppliers()]
   * [DisableRotations()]
@@ -30,6 +35,7 @@ Sets up the Teleport Prefab based on the provided user settings.
   * [NotifyTeleported(TransformPropertyApplier.EventData)]
   * [NotifyTeleporting(TransformPropertyApplier.EventData)]
   * [OnEnable()]
+  * [ResetOffsetAtEndOfFrame()]
   * [Teleport(TransformData)]
 
 ## Details
@@ -47,6 +53,38 @@ Sets up the Teleport Prefab based on the provided user settings.
 
 ```
 public class TeleporterConfigurator : MonoBehaviour
+```
+
+### Fields
+
+#### cachedLocators
+
+A SurfaceLocator collection to store cached versions that get mutated but need changing back after process.
+
+##### Declaration
+
+```
+protected List<SurfaceLocator> cachedLocators
+```
+
+#### cachedSnapToFloorBlinkThreshold
+
+the Facade.SnapToFloorBlinkThreshold value before it is mutated.
+
+##### Declaration
+
+```
+protected float cachedSnapToFloorBlinkThreshold
+```
+
+#### resetCachedDataRoutine
+
+The routine for resetting cached data.
+
+##### Declaration
+
+```
+protected Coroutine resetCachedDataRoutine
 ```
 
 ### Properties
@@ -206,6 +244,16 @@ Configures the surface locator aliases with the offset provided in the facade.
 public virtual void ConfigureSurfaceLocatorAliases()
 ```
 
+#### ConfigureSurfaceLocatorOffsets()
+
+Configures the surface locator rules with the valid targets provided in the facade.
+
+##### Declaration
+
+```
+public virtual void ConfigureSurfaceLocatorOffsets()
+```
+
 #### ConfigureSurfaceLocatorRules()
 
 Configures the surface locator rules with the valid targets provided in the facade.
@@ -286,6 +334,22 @@ public virtual void NotifyTeleporting(TransformPropertyApplier.EventData data)
 protected virtual void OnEnable()
 ```
 
+#### ResetOffsetAtEndOfFrame()
+
+Resets the data mutated by the destination offset update to the original cached values.
+
+##### Declaration
+
+```
+protected virtual IEnumerator ResetOffsetAtEndOfFrame()
+```
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Collections.IEnumerator | An Enumerator to manage the running of the Coroutine. |
+
 #### Teleport(TransformData)
 
 Attempts to teleport the [Target].
@@ -308,6 +372,10 @@ public virtual void Teleport(TransformData destination)
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
+[Fields]: #Fields
+[cachedLocators]: #cachedLocators
+[cachedSnapToFloorBlinkThreshold]: #cachedSnapToFloorBlinkThreshold
+[resetCachedDataRoutine]: #resetCachedDataRoutine
 [Properties]: #Properties
 [CameraColorOverlays]: #CameraColorOverlays
 [Facade]: #Facade
@@ -324,6 +392,7 @@ public virtual void Teleport(TransformData destination)
 [ConfigureRotationAbility(Boolean)]: #ConfigureRotationAbilityBoolean
 [ConfigureSurfaceChangeActions(Single, Single)]: #ConfigureSurfaceChangeActionsSingle-Single
 [ConfigureSurfaceLocatorAliases()]: #ConfigureSurfaceLocatorAliases
+[ConfigureSurfaceLocatorOffsets()]: #ConfigureSurfaceLocatorOffsets
 [ConfigureSurfaceLocatorRules()]: #ConfigureSurfaceLocatorRules
 [ConfigureTransformPropertyAppliers()]: #ConfigureTransformPropertyAppliers
 [DisableRotations()]: #DisableRotations
@@ -331,4 +400,5 @@ public virtual void Teleport(TransformData destination)
 [NotifyTeleported(TransformPropertyApplier.EventData)]: #NotifyTeleportedTransformPropertyApplier.EventData
 [NotifyTeleporting(TransformPropertyApplier.EventData)]: #NotifyTeleportingTransformPropertyApplier.EventData
 [OnEnable()]: #OnEnable
+[ResetOffsetAtEndOfFrame()]: #ResetOffsetAtEndOfFrame
 [Teleport(TransformData)]: #TeleportTransformData

--- a/Documentation/API/TeleporterFacade.md
+++ b/Documentation/API/TeleporterFacade.md
@@ -14,6 +14,7 @@ The public interface into the Teleporter Prefab.
   * [ApplyDestinationRotation]
   * [CameraValidity]
   * [Configuration]
+  * [DestinationOffset]
   * [Offset]
   * [OffsetUsage]
   * [SnapToFloorBlinkThreshold]
@@ -23,6 +24,7 @@ The public interface into the Teleporter Prefab.
 * [Methods]
   * [OnAfterApplyDestinationRotationChange()]
   * [OnAfterCameraValidityChange()]
+  * [OnAfterDestinationOffsetChange()]
   * [OnAfterOffsetChange()]
   * [OnAfterOffsetUsageChange()]
   * [OnAfterSnapToFloorBlinkThresholdChange()]
@@ -105,6 +107,16 @@ The linked Internal Setup.
 public TeleporterConfigurator Configuration { get; protected set; }
 ```
 
+#### DestinationOffset
+
+The position amount to offset the destination teleport position.
+
+##### Declaration
+
+```
+public Vector3 DestinationOffset { get; set; }
+```
+
 #### Offset
 
 The offset to compensate the teleported target position by for both floor snapping and position movement.
@@ -185,6 +197,16 @@ Called after [CameraValidity] has been changed.
 
 ```
 protected virtual void OnAfterCameraValidityChange()
+```
+
+#### OnAfterDestinationOffsetChange()
+
+Called after [DestinationOffset] has been changed.
+
+##### Declaration
+
+```
+protected virtual void OnAfterDestinationOffsetChange()
 ```
 
 #### OnAfterOffsetChange()
@@ -317,6 +339,7 @@ public virtual void Teleport(TransformData destination)
 [Offset]: TeleporterFacade.md#Offset
 [ApplyDestinationRotation]: TeleporterFacade.md#ApplyDestinationRotation
 [CameraValidity]: TeleporterFacade.md#CameraValidity
+[DestinationOffset]: TeleporterFacade.md#DestinationOffset
 [Offset]: TeleporterFacade.md#Offset
 [OffsetUsage]: TeleporterFacade.md#OffsetUsage
 [SnapToFloorBlinkThreshold]: TeleporterFacade.md#SnapToFloorBlinkThreshold
@@ -338,6 +361,7 @@ public virtual void Teleport(TransformData destination)
 [ApplyDestinationRotation]: #ApplyDestinationRotation
 [CameraValidity]: #CameraValidity
 [Configuration]: #Configuration
+[DestinationOffset]: #DestinationOffset
 [Offset]: #Offset
 [OffsetUsage]: #OffsetUsage
 [SnapToFloorBlinkThreshold]: #SnapToFloorBlinkThreshold
@@ -347,6 +371,7 @@ public virtual void Teleport(TransformData destination)
 [Methods]: #Methods
 [OnAfterApplyDestinationRotationChange()]: #OnAfterApplyDestinationRotationChange
 [OnAfterCameraValidityChange()]: #OnAfterCameraValidityChange
+[OnAfterDestinationOffsetChange()]: #OnAfterDestinationOffsetChange
 [OnAfterOffsetChange()]: #OnAfterOffsetChange
 [OnAfterOffsetUsageChange()]: #OnAfterOffsetUsageChange
 [OnAfterSnapToFloorBlinkThresholdChange()]: #OnAfterSnapToFloorBlinkThresholdChange

--- a/Runtime/SharedResources/Scripts/TeleporterFacade.cs
+++ b/Runtime/SharedResources/Scripts/TeleporterFacade.cs
@@ -87,6 +87,12 @@
         [Serialized]
         [field: DocumentedByXml]
         public float SnapToFloorBlinkThreshold { get; set; } = 0.3f;
+        /// <summary>
+        /// The position amount to offset the destination teleport position.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public Vector3 DestinationOffset { get; set; }
         #endregion
 
         #region Teleporter Events
@@ -218,6 +224,15 @@
         protected virtual void OnAfterSnapToFloorBlinkThresholdChange()
         {
             Configuration.ConfigureSurfaceChangeActions(SnapToFloorThreshold, SnapToFloorBlinkThreshold);
+        }
+
+        /// <summary>
+        /// Called after <see cref="DestinationOffset"/> has been changed.
+        /// </summary>
+        [CalledAfterChangeOf(nameof(DestinationOffset))]
+        protected virtual void OnAfterDestinationOffsetChange()
+        {
+            Configuration.ConfigureSurfaceLocatorOffsets();
         }
     }
 }


### PR DESCRIPTION
The new destination offset property allows the teleport destination
to be offset by a given position so it is easier to raise and lower
the character avatar against the found floor surface.