### PR TITLE
fix(Materials): update fade material to use better shader

### DIFF
--- a/Runtime/SharedResources/Materials/TeleportFade.mat
+++ b/Runtime/SharedResources/Materials/TeleportFade.mat
@@ -8,12 +8,12 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: TeleportFade
-  m_Shader: {fileID: 4800000, guid: 97e2b193aea330c42b7faae02c795a9a, type: 3}
+  m_Shader: {fileID: 4800000, guid: 81ca9e7bd24c68543937aa6b06f278bf, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
+  m_CustomRenderQueue: 3001
   stringTagMap: {}
   disabledShaderPasses: []
   m_SavedProperties:


### PR DESCRIPTION
The new TransparentColorBlockout shader is a better, more simpler
shader to use for screen fading and it is also compatible with the
URP approach to screen fading.