### PR TITLE
fix(SnapToFloor): re-enable the camera color overlay component

### DIFF
--- a/Runtime/SharedResources/NestedPrefabs/SnapToFloor.prefab
+++ b/Runtime/SharedResources/NestedPrefabs/SnapToFloor.prefab
@@ -235,7 +235,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &3199935394603094063
 Transform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
The CameraColorOverlay component had been disabled to prevent an
initial blink when the teleporter started at an offset height but
this caused the blink to be always disabled if no offset height was
provided.

The component is now enabled by default and at a later date a further
fix for the offset height blink will be added.