### PR TITLE
fix(prefabs): ensure snap to floor enabled turns off correct object - fixes #86

### DIFF
--- a/Runtime/Prefabs/Locomotors.Teleporter.Dash.prefab
+++ b/Runtime/Prefabs/Locomotors.Teleporter.Dash.prefab
@@ -48,7 +48,7 @@ MonoBehaviour:
   facade: {fileID: 5950170169637845304}
   surfaceTeleporter: {fileID: 4061554705455466048}
   modifyTeleporter: {fileID: 0}
-  snapToFloorContainer: {fileID: 5414941269016037605}
+  snapToFloorContainer: {fileID: 5187678087625464127}
   surfaceLocatorAliases:
   - {fileID: 1549196070032961349}
   surfaceLocatorRules:
@@ -446,6 +446,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 406d478cdbf496a4ead48dfdc7df8d0c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &5187678087625464127 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2088734373560214381, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
+    type: 3}
+  m_PrefabInstance: {fileID: 6558078218179066450}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &7732585858515215388 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3480526847488826958, guid: 3f0f7b61639d6a64fbb972b970f62cd8,

--- a/Runtime/Prefabs/Locomotors.Teleporter.Instant.prefab
+++ b/Runtime/Prefabs/Locomotors.Teleporter.Instant.prefab
@@ -111,7 +111,7 @@ MonoBehaviour:
   facade: {fileID: 6759483569300406686}
   surfaceTeleporter: {fileID: 536479425143457731}
   modifyTeleporter: {fileID: 0}
-  snapToFloorContainer: {fileID: 8756915673802185907}
+  snapToFloorContainer: {fileID: 8456979111799426409}
   surfaceLocatorAliases:
   - {fileID: 2872370309144820499}
   surfaceLocatorRules:
@@ -446,6 +446,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 406d478cdbf496a4ead48dfdc7df8d0c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &8456979111799426409 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2088734373560214381, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
+    type: 3}
+  m_PrefabInstance: {fileID: 7611529125206978052}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &6479771475221442634 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3480526847488826958, guid: 3f0f7b61639d6a64fbb972b970f62cd8,

--- a/Runtime/SharedResources/NestedPrefabs/SnapToFloor.prefab
+++ b/Runtime/SharedResources/NestedPrefabs/SnapToFloor.prefab
@@ -28,7 +28,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 5590959520585286125}
-  - {fileID: 4571630719193713254}
+  - {fileID: 5205323543956018948}
   - {fileID: 2610266345189395638}
   - {fileID: 235444694536354417}
   - {fileID: 8331258515199282043}
@@ -219,6 +219,37 @@ MonoBehaviour:
     field: {fileID: 5655712967484036375}
   onlyProcessOnActiveAndEnabled: 1
   interval: 0
+--- !u!1 &2088734373560214381
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5205323543956018948}
+  m_Layer: 0
+  m_Name: SnapToFloorLogic
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5205323543956018948
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2088734373560214381}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4571630719193713254}
+  m_Father: {fileID: 374839283324289467}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2235965453378203669
 GameObject:
   m_ObjectHideFlags: 0
@@ -378,6 +409,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+  value: 0
   changeDistance: 0.01
   checkAxis:
     xState: 0
@@ -414,8 +446,8 @@ Transform:
   - {fileID: 8757416647604212321}
   - {fileID: 92987762500409198}
   - {fileID: 3077503582736538865}
-  m_Father: {fileID: 374839283324289467}
-  m_RootOrder: 1
+  m_Father: {fileID: 5205323543956018948}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4294519157332793404
 GameObject:
@@ -500,6 +532,7 @@ MonoBehaviour:
   Deactivated:
     m_PersistentCalls:
       m_Calls: []
+  value: 0
   changeDistance: 0.3
   checkAxis:
     xState: 0


### PR DESCRIPTION
The `Snap To Floor Enabled` property was not working correctly as it
was turning off the entire Snap To Floor prefab meaning the blink
logic was also not working as the blink/fade logic is contained within
the Snap To Floor prefab.

The fix is to just turn off the actual surface location logic so the
blink is still accessible.