### PR TITLE
feat(Facade): add teleport ignore floor method

### DIFF
--- a/Documentation/API/TeleporterConfigurator.md
+++ b/Documentation/API/TeleporterConfigurator.md
@@ -22,6 +22,7 @@ Sets up the Teleport Prefab based on the provided user settings.
   * [SurfaceLocatorAliases]
   * [SurfaceLocatorRules]
   * [SurfaceTeleporter]
+  * [TeleportLogicProxy]
   * [TransformPropertyApplierAliases]
   * [TransformPropertyApplierIgnoreOffsetAliases]
 * [Methods]
@@ -40,6 +41,7 @@ Sets up the Teleport Prefab based on the provided user settings.
   * [OnEnable()]
   * [ResetOffsetAtEndOfFrame()]
   * [Teleport(TransformData)]
+  * [TeleportIgnoreFloor(TransformData)]
 
 ## Details
 
@@ -190,6 +192,16 @@ The SurfaceLocator to use for the teleporting event.
 
 ```
 public SurfaceLocator SurfaceTeleporter { get; protected set; }
+```
+
+#### TeleportLogicProxy
+
+The TransformDataProxyEmitter that holds the teleport logic.
+
+##### Declaration
+
+```
+public TransformDataProxyEmitter TeleportLogicProxy { get; protected set; }
 ```
 
 #### TransformPropertyApplierAliases
@@ -399,8 +411,25 @@ public virtual void Teleport(TransformData destination)
 | --- | --- | --- |
 | TransformData | destination | The location to attempt to teleport to. |
 
+#### TeleportIgnoreFloor(TransformData)
+
+Attempts to teleport the [Target] to the exact position without attempting to find the nearest floor.
+
+##### Declaration
+
+```
+public virtual void TeleportIgnoreFloor(TransformData destination)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| TransformData | destination | The location to attempt to teleport to. |
+
 [Tilia.Locomotors.Teleporter]: README.md
 [TeleporterFacade]: TeleporterFacade.md
+[Target]: TeleporterFacade.md#Tilia_Locomotors_Teleporter_TeleporterFacade_Target
 [Target]: TeleporterFacade.md#Tilia_Locomotors_Teleporter_TeleporterFacade_Target
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
@@ -420,6 +449,7 @@ public virtual void Teleport(TransformData destination)
 [SurfaceLocatorAliases]: #SurfaceLocatorAliases
 [SurfaceLocatorRules]: #SurfaceLocatorRules
 [SurfaceTeleporter]: #SurfaceTeleporter
+[TeleportLogicProxy]: #TeleportLogicProxy
 [TransformPropertyApplierAliases]: #TransformPropertyApplierAliases
 [TransformPropertyApplierIgnoreOffsetAliases]: #TransformPropertyApplierIgnoreOffsetAliases
 [Methods]: #Methods
@@ -438,3 +468,4 @@ public virtual void Teleport(TransformData destination)
 [OnEnable()]: #OnEnable
 [ResetOffsetAtEndOfFrame()]: #ResetOffsetAtEndOfFrame
 [Teleport(TransformData)]: #TeleportTransformData
+[TeleportIgnoreFloor(TransformData)]: #TeleportIgnoreFloorTransformData

--- a/Documentation/API/TeleporterFacade.md
+++ b/Documentation/API/TeleporterFacade.md
@@ -43,6 +43,11 @@ The public interface into the Teleporter Prefab.
   * [Teleport(Transform)]
   * [Teleport(TransformData)]
   * [Teleport(Vector3)]
+  * [TeleportIgnoreFloor(GameObject)]
+  * [TeleportIgnoreFloor(Transform)]
+  * [TeleportIgnoreFloor(TransformData)]
+  * [TeleportIgnoreFloor(Vector3)]
+  * [Vector3ToTransformData(Vector3)]
 
 ## Details
 
@@ -365,7 +370,7 @@ public virtual void SetOffsetUsage(int offsetTypeIndex)
 
 #### Teleport(GameObject)
 
-Attempts to teleport the [Target].
+Attempts to teleport the [Target] above a collidable floor.
 
 ##### Declaration
 
@@ -381,7 +386,7 @@ public virtual void Teleport(GameObject destination)
 
 #### Teleport(Transform)
 
-Attempts to teleport the [Target].
+Attempts to teleport the [Target] above a collidable floor.
 
 ##### Declaration
 
@@ -397,7 +402,7 @@ public virtual void Teleport(Transform destination)
 
 #### Teleport(TransformData)
 
-Attempts to teleport the [Target].
+Attempts to teleport the [Target] above a collidable floor.
 
 ##### Declaration
 
@@ -413,7 +418,7 @@ public virtual void Teleport(TransformData destination)
 
 #### Teleport(Vector3)
 
-Attempts to teleport the [Target] to the given world position.
+Attempts to teleport the [Target] to the given world position above a collidable floor.
 
 ##### Declaration
 
@@ -426,6 +431,92 @@ public virtual void Teleport(Vector3 destinationPosition)
 | Type | Name | Description |
 | --- | --- | --- |
 | Vector3 | destinationPosition | n/a |
+
+#### TeleportIgnoreFloor(GameObject)
+
+Attempts to teleport the [Target] but does not require a collidable floor underneath the destination.
+
+##### Declaration
+
+```
+public virtual void TeleportIgnoreFloor(GameObject destination)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| GameObject | destination | The location to attempt to teleport to. |
+
+#### TeleportIgnoreFloor(Transform)
+
+Attempts to teleport the [Target] but does not require a collidable floor underneath the destination.
+
+##### Declaration
+
+```
+public virtual void TeleportIgnoreFloor(Transform destination)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| Transform | destination | The location to attempt to teleport to. |
+
+#### TeleportIgnoreFloor(TransformData)
+
+Attempts to teleport the [Target] but does not require a collidable floor underneath the destination.
+
+##### Declaration
+
+```
+public virtual void TeleportIgnoreFloor(TransformData destination)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| TransformData | destination | The location to attempt to teleport to. |
+
+#### TeleportIgnoreFloor(Vector3)
+
+Attempts to teleport the [Target] but does not require a collidable floor underneath the destination.
+
+##### Declaration
+
+```
+public virtual void TeleportIgnoreFloor(Vector3 destinationPosition)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| Vector3 | destinationPosition | n/a |
+
+#### Vector3ToTransformData(Vector3)
+
+Converts Vector3 to TransformData.
+
+##### Declaration
+
+```
+protected virtual TransformData Vector3ToTransformData(Vector3 data)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| Vector3 | data | The data to convert. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| TransformData | The converted data. |
 
 [Tilia.Locomotors.Teleporter]: README.md
 [Target]: TeleporterFacade.md#Target
@@ -449,6 +540,10 @@ public virtual void Teleport(Vector3 destinationPosition)
 [TargetValidity]: TeleporterFacade.md#TargetValidity
 [OffsetUsage]: TeleporterFacade.md#OffsetUsage
 [TeleporterFacade.OffsetType]: TeleporterFacade.OffsetType.md
+[Target]: TeleporterFacade.md#Target
+[Target]: TeleporterFacade.md#Target
+[Target]: TeleporterFacade.md#Target
+[Target]: TeleporterFacade.md#Target
 [Target]: TeleporterFacade.md#Target
 [Target]: TeleporterFacade.md#Target
 [Target]: TeleporterFacade.md#Target
@@ -492,3 +587,8 @@ public virtual void Teleport(Vector3 destinationPosition)
 [Teleport(Transform)]: #TeleportTransform
 [Teleport(TransformData)]: #TeleportTransformData
 [Teleport(Vector3)]: #TeleportVector3
+[TeleportIgnoreFloor(GameObject)]: #TeleportIgnoreFloorGameObject
+[TeleportIgnoreFloor(Transform)]: #TeleportIgnoreFloorTransform
+[TeleportIgnoreFloor(TransformData)]: #TeleportIgnoreFloorTransformData
+[TeleportIgnoreFloor(Vector3)]: #TeleportIgnoreFloorVector3
+[Vector3ToTransformData(Vector3)]: #Vector3ToTransformDataVector3

--- a/Runtime/Prefabs/Locomotors.Teleporter.Dash.prefab
+++ b/Runtime/Prefabs/Locomotors.Teleporter.Dash.prefab
@@ -46,8 +46,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   facade: {fileID: 5950170169637845304}
+  teleportLogicProxy: {fileID: 1188221514831923064}
   surfaceTeleporter: {fileID: 4061554705455466048}
-  modifyTeleporter: {fileID: 0}
+  modifyTeleporter: {fileID: 1830882504103230646}
   snapToFloorContainer: {fileID: 5187678087625464127}
   surfaceLocatorAliases:
   - {fileID: 1549196070032961349}
@@ -136,6 +137,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8221229427137139004}
   - component: {fileID: 4061554705455466048}
+  - component: {fileID: 1188221514831923064}
   - component: {fileID: 1830882504103230646}
   m_Layer: 0
   m_Name: DashMovement
@@ -187,6 +189,35 @@ MonoBehaviour:
   SurfaceLocated:
     m_PersistentCalls:
       m_Calls:
+      - m_Target: {fileID: 1188221514831923064}
+        m_MethodName: Receive
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1188221514831923064
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5435332709518248266}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a305eb4700f2a7546b29ea5efe8c17dd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  payload:
+    transform: {fileID: 0}
+    useLocalValues: 0
+  Emitted:
+    m_PersistentCalls:
+      m_Calls:
       - m_Target: {fileID: 1830882504103230646}
         m_MethodName: set_Source
         m_Mode: 0
@@ -209,6 +240,8 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+  receiveValidity:
+    field: {fileID: 0}
 --- !u!114 &1830882504103230646
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Runtime/Prefabs/Locomotors.Teleporter.Instant.prefab
+++ b/Runtime/Prefabs/Locomotors.Teleporter.Instant.prefab
@@ -109,8 +109,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   facade: {fileID: 6759483569300406686}
+  teleportLogicProxy: {fileID: 3445463111050495131}
   surfaceTeleporter: {fileID: 536479425143457731}
-  modifyTeleporter: {fileID: 0}
+  modifyTeleporter: {fileID: 103839708580330939}
   snapToFloorContainer: {fileID: 8456979111799426409}
   surfaceLocatorAliases:
   - {fileID: 2872370309144820499}
@@ -136,6 +137,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1472956425516877046}
   - component: {fileID: 536479425143457731}
+  - component: {fileID: 3445463111050495131}
   - component: {fileID: 103839708580330939}
   m_Layer: 0
   m_Name: Teleportation
@@ -187,6 +189,35 @@ MonoBehaviour:
   SurfaceLocated:
     m_PersistentCalls:
       m_Calls:
+      - m_Target: {fileID: 3445463111050495131}
+        m_MethodName: Receive
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &3445463111050495131
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6210428687401589529}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a305eb4700f2a7546b29ea5efe8c17dd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  payload:
+    transform: {fileID: 0}
+    useLocalValues: 0
+  Emitted:
+    m_PersistentCalls:
+      m_Calls:
       - m_Target: {fileID: 103839708580330939}
         m_MethodName: set_Source
         m_Mode: 0
@@ -220,6 +251,8 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+  receiveValidity:
+    field: {fileID: 0}
 --- !u!114 &103839708580330939
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Runtime/SharedResources/Scripts/TeleporterConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/TeleporterConfigurator.cs
@@ -7,6 +7,7 @@
     using Zinnia.Data.Attribute;
     using Zinnia.Data.Enum;
     using Zinnia.Data.Type;
+    using Zinnia.Event.Proxy;
     using Zinnia.Tracking;
     using Zinnia.Tracking.Modification;
     using Zinnia.Visual;
@@ -40,6 +41,24 @@
 
         #region Teleporter Settings
         [Header("Teleporter Settings")]
+        [Tooltip("The TransformDataProxyEmitter that holds the teleport logic.")]
+        [SerializeField]
+        [Restricted]
+        private TransformDataProxyEmitter teleportLogicProxy;
+        /// <summary>
+        /// The <see cref="TransformDataProxyEmitter"/> that holds the teleport logic.
+        /// </summary>
+        public TransformDataProxyEmitter TeleportLogicProxy
+        {
+            get
+            {
+                return teleportLogicProxy;
+            }
+            protected set
+            {
+                teleportLogicProxy = value;
+            }
+        }
         [Tooltip("The SurfaceLocator to use for the teleporting event.")]
         [SerializeField]
         [Restricted]
@@ -252,12 +271,23 @@
             if (SurfaceTeleporter != null)
             {
                 SurfaceTeleporter.Locate(destination);
+                return;
             }
-
-            if (ModifyTeleporter != null)
+            else
             {
-                ModifyTeleporter.Source = destination;
-                ModifyTeleporter.Apply();
+                TeleportIgnoreFloor(destination);
+            }
+        }
+
+        /// <summary>
+        /// Attempts to teleport the <see cref="TeleporterFacade.Target"/> to the exact position without attempting to find the nearest floor.
+        /// </summary>
+        /// <param name="destination">The location to attempt to teleport to.</param>
+        public virtual void TeleportIgnoreFloor(TransformData destination)
+        {
+            if (TeleportLogicProxy != null)
+            {
+                TeleportLogicProxy.Receive(destination);
             }
         }
 

--- a/Runtime/SharedResources/Scripts/TeleporterFacade.cs
+++ b/Runtime/SharedResources/Scripts/TeleporterFacade.cs
@@ -349,7 +349,16 @@
         }
 
         /// <summary>
-        /// Attempts to teleport the <see cref="Target"/>.
+        /// Sets <see cref="OffsetUsage"/>.
+        /// </summary>
+        /// <param name="offsetTypeIndex">The index of the <see cref="OffsetType"/>.</param>
+        public virtual void SetOffsetUsage(int offsetTypeIndex)
+        {
+            OffsetUsage = EnumExtensions.GetByIndex<OffsetType>(offsetTypeIndex);
+        }
+
+        /// <summary>
+        /// Attempts to teleport the <see cref="Target"/> above a collidable floor.
         /// </summary>
         /// <param name="destination">The location to attempt to teleport to.</param>
         public virtual void Teleport(Transform destination)
@@ -358,7 +367,7 @@
         }
 
         /// <summary>
-        /// Attempts to teleport the <see cref="Target"/>.
+        /// Attempts to teleport the <see cref="Target"/> above a collidable floor.
         /// </summary>
         /// <param name="destination">The location to attempt to teleport to.</param>
         public virtual void Teleport(GameObject destination)
@@ -367,7 +376,7 @@
         }
 
         /// <summary>
-        /// Attempts to teleport the <see cref="Target"/>.
+        /// Attempts to teleport the <see cref="Target"/> above a collidable floor.
         /// </summary>
         /// <param name="destination">The location to attempt to teleport to.</param>
         public virtual void Teleport(TransformData destination)
@@ -376,25 +385,62 @@
         }
 
         /// <summary>
-        /// Attempts to teleport the <see cref="Target"/> to the given world position.
+        /// Attempts to teleport the <see cref="Target"/> to the given world position above a collidable floor.
         /// </summary>
         /// <param name="destination">The world position to attempt to teleport to.</param>
         public virtual void Teleport(Vector3 destinationPosition)
         {
-            GameObject transformLocation = new GameObject();
-            TransformData destination = new TransformData(transformLocation.transform);
-            destination.PositionOverride = destinationPosition;
-            Teleport(destination);
-            Destroy(transformLocation);
+            Teleport(Vector3ToTransformData(destinationPosition));
         }
 
         /// <summary>
-        /// Sets <see cref="OffsetUsage"/>.
+        /// Attempts to teleport the <see cref="Target"/> but does not require a collidable floor underneath the destination.
         /// </summary>
-        /// <param name="offsetTypeIndex">The index of the <see cref="OffsetType"/>.</param>
-        public virtual void SetOffsetUsage(int offsetTypeIndex)
+        /// <param name="destination">The location to attempt to teleport to.</param>
+        public virtual void TeleportIgnoreFloor(Transform destination)
         {
-            OffsetUsage = EnumExtensions.GetByIndex<OffsetType>(offsetTypeIndex);
+            TeleportIgnoreFloor(new TransformData(destination));
+        }
+
+        /// <summary>
+        /// Attempts to teleport the <see cref="Target"/> but does not require a collidable floor underneath the destination.
+        /// </summary>
+        /// <param name="destination">The location to attempt to teleport to.</param>
+        public virtual void TeleportIgnoreFloor(GameObject destination)
+        {
+            TeleportIgnoreFloor(new TransformData(destination));
+        }
+
+        /// <summary>
+        /// Attempts to teleport the <see cref="Target"/> but does not require a collidable floor underneath the destination.
+        /// </summary>
+        /// <param name="destination">The location to attempt to teleport to.</param>
+        public virtual void TeleportIgnoreFloor(TransformData destination)
+        {
+            Configuration.TeleportIgnoreFloor(destination);
+        }
+
+        /// <summary>
+        /// Attempts to teleport the <see cref="Target"/> but does not require a collidable floor underneath the destination.
+        /// </summary>
+        /// <param name="destination">The world position to attempt to teleport to.</param>
+        public virtual void TeleportIgnoreFloor(Vector3 destinationPosition)
+        {
+            TeleportIgnoreFloor(Vector3ToTransformData(destinationPosition));
+        }
+
+        /// <summary>
+        /// Converts <see cref="Vector3"/> to <see cref="TransformData"/>.
+        /// </summary>
+        /// <param name="data">The data to convert.</param>
+        /// <returns>The converted data.</returns>
+        protected virtual TransformData Vector3ToTransformData(Vector3 data)
+        {
+            GameObject transformLocation = new GameObject();
+            TransformData destination = new TransformData(transformLocation.transform);
+            destination.PositionOverride = data;
+            Destroy(transformLocation);
+            return destination;
         }
 
         /// <summary>


### PR DESCRIPTION
The new TeleportIgnoreFloor method will teleport the Target to the
given destination even if there is no collidable floor underneath
the destination.