### PR TITLE
fix(Prefabs): ensure snap to floor moves along sloped objects

### DIFF
--- a/Documentation/API/TeleporterConfigurator.md
+++ b/Documentation/API/TeleporterConfigurator.md
@@ -111,7 +111,7 @@ The scene Cameras to set the CameraColorOverlays to affect.
 ##### Declaration
 
 ```
-public List<CameraColorOverlay> CameraColorOverlays { get; protected set; }
+public List<CameraColorOverlay> CameraColorOverlays { get; set; }
 ```
 
 #### Facade
@@ -121,7 +121,7 @@ The public interface facade.
 ##### Declaration
 
 ```
-public TeleporterFacade Facade { get; protected set; }
+public TeleporterFacade Facade { get; set; }
 ```
 
 #### ModifyTeleporter
@@ -131,7 +131,7 @@ The TransformPropertyApplier to use for the teleporting event.
 ##### Declaration
 
 ```
-public TransformPropertyApplier ModifyTeleporter { get; protected set; }
+public TransformPropertyApplier ModifyTeleporter { get; set; }
 ```
 
 #### SnapToFloorBlinkThresholdController
@@ -141,7 +141,7 @@ The SurfaceChangeAction that holds the threshold of whether a blink should occur
 ##### Declaration
 
 ```
-public SurfaceChangeAction SnapToFloorBlinkThresholdController { get; protected set; }
+public SurfaceChangeAction SnapToFloorBlinkThresholdController { get; set; }
 ```
 
 #### SnapToFloorContainer
@@ -151,7 +151,7 @@ The GameObject that contains the snap to floor controller logic.
 ##### Declaration
 
 ```
-public GameObject SnapToFloorContainer { get; protected set; }
+public GameObject SnapToFloorContainer { get; set; }
 ```
 
 #### SnapToFloorThresholdController
@@ -161,7 +161,7 @@ The SurfaceChangeAction that holds the threshold of whether a snap to floor shou
 ##### Declaration
 
 ```
-public SurfaceChangeAction SnapToFloorThresholdController { get; protected set; }
+public SurfaceChangeAction SnapToFloorThresholdController { get; set; }
 ```
 
 #### SurfaceLocatorAliases
@@ -171,7 +171,7 @@ The SurfaceLocator to set aliases on.
 ##### Declaration
 
 ```
-public List<SurfaceLocator> SurfaceLocatorAliases { get; protected set; }
+public List<SurfaceLocator> SurfaceLocatorAliases { get; set; }
 ```
 
 #### SurfaceLocatorRules
@@ -181,7 +181,7 @@ The SurfaceLocator to set rules on.
 ##### Declaration
 
 ```
-public List<SurfaceLocator> SurfaceLocatorRules { get; protected set; }
+public List<SurfaceLocator> SurfaceLocatorRules { get; set; }
 ```
 
 #### SurfaceTeleporter
@@ -191,7 +191,7 @@ The SurfaceLocator to use for the teleporting event.
 ##### Declaration
 
 ```
-public SurfaceLocator SurfaceTeleporter { get; protected set; }
+public SurfaceLocator SurfaceTeleporter { get; set; }
 ```
 
 #### TeleportLogicProxy
@@ -201,7 +201,7 @@ The TransformDataProxyEmitter that holds the teleport logic.
 ##### Declaration
 
 ```
-public TransformDataProxyEmitter TeleportLogicProxy { get; protected set; }
+public TransformDataProxyEmitter TeleportLogicProxy { get; set; }
 ```
 
 #### TransformPropertyApplierAliases
@@ -211,7 +211,7 @@ The TransformPropertyApplier collection to set aliases on.
 ##### Declaration
 
 ```
-public List<TransformPropertyApplier> TransformPropertyApplierAliases { get; protected set; }
+public List<TransformPropertyApplier> TransformPropertyApplierAliases { get; set; }
 ```
 
 #### TransformPropertyApplierIgnoreOffsetAliases
@@ -221,7 +221,7 @@ The TransformPropertyApplier collection to ignore offsets on.
 ##### Declaration
 
 ```
-public List<TransformPropertyApplier> TransformPropertyApplierIgnoreOffsetAliases { get; protected set; }
+public List<TransformPropertyApplier> TransformPropertyApplierIgnoreOffsetAliases { get; set; }
 ```
 
 ### Methods

--- a/Documentation/API/TeleporterFacade.md
+++ b/Documentation/API/TeleporterFacade.md
@@ -117,7 +117,7 @@ The linked Internal Setup.
 ##### Declaration
 
 ```
-public TeleporterConfigurator Configuration { get; protected set; }
+public TeleporterConfigurator Configuration { get; set; }
 ```
 
 #### DestinationOffset

--- a/Runtime/Prefabs/Locomotors.Teleporter.Dash.prefab
+++ b/Runtime/Prefabs/Locomotors.Teleporter.Dash.prefab
@@ -74,6 +74,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7466508404443556258}
   - component: {fileID: 5950170169637845304}
+  - component: {fileID: 7359690121777799856}
   m_Layer: 0
   m_Name: Locomotors.Teleporter.Dash
   m_TagString: Untagged
@@ -127,6 +128,22 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   configuration: {fileID: 1683957728789067024}
+--- !u!114 &7359690121777799856
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2262987785075144963}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 7561676446728792176}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0
 --- !u!1 &5435332709518248266
 GameObject:
   m_ObjectHideFlags: 0
@@ -563,3 +580,15 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 6558078218179066450}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &7561676446728792176 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3743196964653568546, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
+    type: 3}
+  m_PrefabInstance: {fileID: 6558078218179066450}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c0eab237e25807459af1c5caf4d3d33, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Runtime/Prefabs/Locomotors.Teleporter.Instant.prefab
+++ b/Runtime/Prefabs/Locomotors.Teleporter.Instant.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8762128706450136148}
   - component: {fileID: 6759483569300406686}
+  - component: {fileID: 3417548301590814049}
   m_Layer: 0
   m_Name: Locomotors.Teleporter.Instant
   m_TagString: Untagged
@@ -63,6 +64,22 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   configuration: {fileID: 831700923211128871}
+--- !u!114 &3417548301590814049
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2787178629607972807}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 6508568598066199590}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0
 --- !u!1 &6091841197206593970
 GameObject:
   m_ObjectHideFlags: 0
@@ -557,3 +574,15 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 7611529125206978052}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &6508568598066199590 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3743196964653568546, guid: 3f0f7b61639d6a64fbb972b970f62cd8,
+    type: 3}
+  m_PrefabInstance: {fileID: 7611529125206978052}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c0eab237e25807459af1c5caf4d3d33, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Runtime/SharedResources/NestedPrefabs/SnapToFloor.prefab
+++ b/Runtime/SharedResources/NestedPrefabs/SnapToFloor.prefab
@@ -358,6 +358,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d1d120f24812793439e55c40dd45fccb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  emitEvents: 1
   ActivationStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -388,6 +389,17 @@ MonoBehaviour:
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 1
+        m_CallState: 2
+      - m_Target: {fileID: 3660979598859947251}
+        m_MethodName: ResetToDefaultValue
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
         m_CallState: 2
   ValueChanged:
     m_PersistentCalls:
@@ -492,6 +504,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d1d120f24812793439e55c40dd45fccb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  emitEvents: 1
   ActivationStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -522,6 +535,17 @@ MonoBehaviour:
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 1
+        m_CallState: 2
+      - m_Target: {fileID: 7218734259541283729}
+        m_MethodName: ResetToDefaultValue
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
         m_CallState: 2
   ValueChanged:
     m_PersistentCalls:

--- a/Runtime/SharedResources/Scripts/TeleporterConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/TeleporterConfigurator.cs
@@ -32,7 +32,7 @@
             {
                 return facade;
             }
-            protected set
+            set
             {
                 facade = value;
             }
@@ -54,7 +54,7 @@
             {
                 return teleportLogicProxy;
             }
-            protected set
+            set
             {
                 teleportLogicProxy = value;
             }
@@ -72,7 +72,7 @@
             {
                 return surfaceTeleporter;
             }
-            protected set
+            set
             {
                 surfaceTeleporter = value;
             }
@@ -90,7 +90,7 @@
             {
                 return modifyTeleporter;
             }
-            protected set
+            set
             {
                 modifyTeleporter = value;
             }
@@ -108,7 +108,7 @@
             {
                 return snapToFloorContainer;
             }
-            protected set
+            set
             {
                 snapToFloorContainer = value;
             }
@@ -130,7 +130,7 @@
             {
                 return surfaceLocatorAliases;
             }
-            protected set
+            set
             {
                 surfaceLocatorAliases = value;
             }
@@ -148,7 +148,7 @@
             {
                 return surfaceLocatorRules;
             }
-            protected set
+            set
             {
                 surfaceLocatorRules = value;
             }
@@ -166,7 +166,7 @@
             {
                 return transformPropertyApplierAliases;
             }
-            protected set
+            set
             {
                 transformPropertyApplierAliases = value;
             }
@@ -184,7 +184,7 @@
             {
                 return transformPropertyApplierIgnoreOffsetAliases;
             }
-            protected set
+            set
             {
                 transformPropertyApplierIgnoreOffsetAliases = value;
             }
@@ -202,7 +202,7 @@
             {
                 return cameraColorOverlays;
             }
-            protected set
+            set
             {
                 cameraColorOverlays = value;
             }
@@ -220,7 +220,7 @@
             {
                 return snapToFloorThresholdController;
             }
-            protected set
+            set
             {
                 snapToFloorThresholdController = value;
             }
@@ -238,7 +238,7 @@
             {
                 return snapToFloorBlinkThresholdController;
             }
-            protected set
+            set
             {
                 snapToFloorBlinkThresholdController = value;
             }

--- a/Runtime/SharedResources/Scripts/TeleporterFacade.cs
+++ b/Runtime/SharedResources/Scripts/TeleporterFacade.cs
@@ -276,7 +276,7 @@
             {
                 return configuration;
             }
-            protected set
+            set
             {
                 configuration = value;
             }


### PR DESCRIPTION
The Snap To Floor logic was not moving along sloped objects because the surface change action was only triggering once when the surface changed, but if the position changed over the same object then it was not triggering a new change event.

This has been fixed now by an update to the Zinnia Action class that allows the action value to be reset so it is now reset after the activated action is emitted in the surface change action so the next time it is checked, the action can still be emitted.

The MomentProcessor within the teleporter prefabs is also exposed onto a top level MomentProcess on the teleporter prefabs so it can be easily added to another MomentProcessor.