### PR TITLE
fix(prefabs): remove empty listener from pause snapping - fixes #113

### DIFF
--- a/Runtime/SharedResources/NestedPrefabs/SnapToFloor.prefab
+++ b/Runtime/SharedResources/NestedPrefabs/SnapToFloor.prefab
@@ -975,17 +975,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_MethodName: 
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: 
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
 --- !u!1 &8440662306268692062
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
The Pause Snapping Logic had an empty listener that has now been removed as it wasn't doing anything.